### PR TITLE
Since we are using `npm ci` there is no point in saving noe_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,22 +14,10 @@ jobs:
     steps:
       - checkout
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
       - run:
           name: Install dependencies
           command: |
             npm ci
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
 
       # Run linters and tests
       - run:


### PR DESCRIPTION
NPM would drop them anyway